### PR TITLE
Fix running of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ RUN useradd -r maxscale && \
 # Run as non root. Required for OpenShift container certification.
 USER maxscale
 
-ENTRYPOINT ["maxscale","--nodaemon", "--user=maxscale", "--log=stdout"]
+ENTRYPOINT ["maxscale","--nodaemon", "--log=stdout"]
 


### PR DESCRIPTION
It is not allowed and not necessary --user parametr in entrypoint because of already applied USER directive earlier in dockerfile. Moreover with --user in entrypoint builded docker image does not work (at least in debian). we can apply --user parametr only if USER root directive used, but it is not conformant to openshift container certification. For USER maxscale we get access denied (maxscale user does not have such privilege).

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
